### PR TITLE
実装のリファクタリング

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+venv

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 venv
+.gitignore

--- a/free-memo.py
+++ b/free-memo.py
@@ -1,74 +1,168 @@
 import tkinter as tk
-import tkinter as t
 from tkinter.scrolledtext import ScrolledText
 import os
 import datetime
 
-# def用変数定義
-word_count = 0
-daily_dir = "i:\\Knowledge_BackUP\\Daily"
-today_data = datetime.date.today()
-date_format = "%Y-%m-%d"
-time_format = "%H:%M"
-daily_today = today_data.strftime(date_format)
-file_path = f"{os.path.join(daily_dir,daily_today)}.md"
+
+def original():
+    # def用変数定義
+    word_count = 0
+    daily_dir = "i:\\Knowledge_BackUP\\Daily"
+    today_data = datetime.date.today()
+    date_format = "%Y-%m-%d"
+    time_format = "%H:%M"
+    daily_today = today_data.strftime(date_format)
+    file_path = f"{os.path.join(daily_dir, daily_today)}.md"
+
+    # 文字数カウントdef
+    def entry_count():
+        global word_count
+        word_count = entry.get(0.0, tk.END)
+        count_label["text"] = len(word_count) - 1
+        root.after(1000, entry_count)
+
+    # ボタンクリックdef
+    def send_button_click():
+        daily_file = open(file_path, mode="a", encoding="UTF-8")
+        daily_file.write(f"**{now()}**\n{entry.get(0.0, tk.END)}\n")
+        entry.delete(0.0, tk.END)
+        daily_file.close()
+
+    # 現在の取得を取得def
+    def now():
+        global time_format
+        time_data = datetime.datetime.now().time()
+        time_now = time_data.strftime(time_format)
+        return time_now
+
+    # メインウィンドウ作成
+    root = tk.Tk()
+    root.title("フリーメモ")
+    root.geometry("600x220")
+
+    # テキストフレーム・テキストボックス作成
+    text_frame = tk.Frame(root, width=500, height=100)
+    text_frame.pack()
+    entry = ScrolledText(text_frame, font=("Meiryo UI", 12), height=7, width=55)
+    entry.pack()
+
+    # 送信・文字数カウントラベル作成
+    frame = tk.Frame(root, width=500, height=30)
+    frame.pack(padx=20, pady=10)
+
+    count_label = tk.Label(frame, text=0, width="10", font=("Meiryo UI", 14))
+    entry_count()
+    count_label.grid(row=0, column=0)
+
+    send_button = tk.Button(
+        frame,
+        text="送信",
+        width="35",
+        pady=5,
+        fg="#ffffff",
+        bg="#1E88E5",
+        relief=tk.FLAT,
+        font=("Meiryo UI", 14),
+        anchor="center",
+        command=send_button_click,
+    )
+    send_button.grid(row=0, column=1)
+
+    root.mainloop()
 
 
-# 文字数カウントdef
-def entry_count():
-    global word_count
-    word_count = entry.get(0.0, t.END)
-    count_label["text"] = len(word_count) - 1
-    root.after(1000, entry_count)
+# ==================================================================================
+
+def create_text_frame(master):
+    text_frame = tk.Frame(master, width=500, height=100)
+    text_field = ScrolledText(text_frame, font=("Meiryo UI", 12), height=7, width=55)
+    text_field.pack()
+    return text_frame, text_field
 
 
-# ボタンクリックdef
-def send_button_click():
-    daily_file = open(file_path, mode="a", encoding="UTF-8")
-    daily_file.write(f"**{now()}**\n{entry.get(0.0, t.END)}\n")
-    entry.delete(0.0, t.END)
-    daily_file.close()
+def create_counter(master):
+    counter = tk.Label(master, text=0, width="10", font=("Meiryo UI", 14))
+    return counter
 
 
-# 現在の取得を取得def
-def now():
-    global time_format
-    time_data = datetime.datetime.now().time()
-    time_now = time_data.strftime(time_format)
-    return time_now
+def create_send_button(master, command):
+    send_button = tk.Button(
+        master,
+        text="送信",
+        width="35",
+        pady=5,
+        fg="#ffffff",
+        bg="#1E88E5",
+        relief=tk.FLAT,
+        font=("Meiryo UI", 14),
+        anchor="center",
+        command=command,
+    )
+    return send_button
 
 
-# メインウィンドウ作成
-root = tk.Tk()
-root.title("フリーメモ")
-root.geometry("600x220")
+def save_and_clear_text(target_path: str, text_widget: ScrolledText, timestamp_format: str):
+    template = "**{:" + timestamp_format + "}**\n{}\n"
 
-# テキストフレーム・テキストボックス作成
-text_frame = tk.Frame(root, width=500, height=100)
-text_frame.pack()
-entry = ScrolledText(text_frame, font=("Meiryo UI", 12), height=7, width=55)
-entry.pack()
+    with open(target_path, mode="a", encoding="UTF-8") as f:
+        timestamp = datetime.datetime.now()
+        body = text_widget.get(0.0, tk.END)
+        f.write(template.format(timestamp, body))
 
-# 送信・文字数カウントラベル作成
-frame = tk.Frame(root, width=500, height=30)
-frame.pack(padx=20, pady=10)
+    text_widget.delete(0.0, tk.END)
 
-count_label = tk.Label(frame, text=0, width="10", font=("Meiryo UI", 14))
-entry_count()
-count_label.grid(row=0, column=0)
 
-send_button = tk.Button(
-    frame,
-    text="送信",
-    width="35",
-    pady=5,
-    fg="#ffffff",
-    bg="#1E88E5",
-    relief=tk.FLAT,
-    font=("Meiryo UI", 14),
-    anchor="center",
-    command=send_button_click,
-)
-send_button.grid(row=0, column=1)
+def create_main_window(master, file_path, timestamp_format):
+    main_window = tk.Frame(master)
 
-root.mainloop()
+    text_frame, text_field = create_text_frame(main_window)
+    text_frame.pack()
+
+    counter_button_frame = tk.Frame(main_window, width=500, height=30)
+    counter_button_frame.pack(padx=20, pady=10)
+    counter = create_counter(counter_button_frame)
+    counter.grid(row=0, column=0)
+
+    def send_button_click():
+        # 変数のスコープを犯す(引数でもらっていない変数を処理に使う)という「変な」ことをするので、
+        # それ以外の変わったことを極力同じところでしないことで認知負荷を下げる
+        return save_and_clear_text(file_path, text_field, timestamp_format)
+
+    send_button = create_send_button(counter_button_frame, send_button_click)
+    send_button.grid(row=0, column=1)
+
+    def launch_auto_sync(root, *, period_ms=1000):  # 普通はクラスで実現する
+        def one_step():
+            text = text_field.get(0.0, tk.END)
+            counter["text"] = len(text) - 1
+            root.after(period_ms, one_step)
+
+        one_step()
+
+    return main_window, launch_auto_sync
+
+
+def launch_app(save_file_path: str, timestamp_format: str, *, sync_period_ms=1000):
+    root = tk.Tk()
+    root.title("フリーメモ")
+    root.geometry("600x220")
+
+    main_window, launch_auto_sync = create_main_window(root, save_file_path, timestamp_format)
+    main_window.pack()
+
+    launch_auto_sync(root, period_ms=sync_period_ms)
+    root.mainloop()
+
+
+def main():
+    # 平時にいじる部分は一か所にまとめる
+    save_dir = "i:\\Knowledge_BackUP\\Daily"
+    file_name = f"{datetime.date.today():%Y-%m-%d}.md"
+    file_path = os.path.join(save_dir, file_name)
+    timestamp_format = "%H:%M"
+
+    launch_app(file_path, timestamp_format, sync_period_ms=10)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
以下変更点です

[1] グローバル変数の除去
グローバル変数は「いかなるところからもアクセスできる変数」です。どこからでも自由に読み書きできるので、書くときは便利な反面、コードを読む立場だと「この変数、いつどのタイミングで変わったんだ・・・？」とか「関数の中でいきなりよくわからん変数出てきたけど、こんなところにおった」とかが起きて、極めて厳しい状態になります。また仕様変更の際、グローバル変数に手を入れたくなった場合、影響範囲がどこまでなのか調査するのが極めて困難になります。
以上の理由から、グローバル変数を使ったプログラミングは (極めて限定的な状況を除いて) 悪手です。
今回のリファクタリングではグローバル変数を使う代わりに、関数の引数で値を渡していく方式で極力実現するようにしました。

[2] コントロールする変数を一か所にまとめる
もともとこれは実現できていたのですが、今回の変更で main 関数内に動かしました。今後運用する際、main 関数部分以外の部分はほぼ見なくてよいことになります。またすこし前処理を入れたいとか後処理を入れたいというのはよくあることですが、その際に編集する可能性のある個所にまとめておく、という点は改善点かもしれません。

[3] 文字数とカウンタの同期開始タイミングを mainloop のタイミングとほぼ同時に変更
もともとの実装ではウィジェットの配置やイベントハンドラの設定の途中で同期をすでに開始しているような形になっていましたが (厳密にはたぶん一回だけ動いた後停止している状態)、開始タイミングを .mainloop のすぐ近くにするように変更しました。

他多少細々変更してますが、あまり細かい部分は変更してません。